### PR TITLE
feat(packs): PDP added;

### DIFF
--- a/live.gen.ts
+++ b/live.gen.ts
@@ -3,8 +3,9 @@
 // This file is automatically updated during development when running `dev.ts`.
 
 import * as $$0 from "./accounts/configStore.ts";
-import * as $$$0 from "./loaders/product/productList.ts";
-import * as $$$1 from "./loaders/store/session.ts";
+import * as $$$0 from "./loaders/product/productDetails.ts";
+import * as $$$1 from "./loaders/product/productList.ts";
+import * as $$$2 from "./loaders/store/session.ts";
 import * as $$$$0 from "./routes/styles.css.ts";
 import * as $$$$1 from "./routes/_app.tsx";
 import * as $$$$2 from "./routes/_middleware.tsx";
@@ -220,8 +221,9 @@ const manifest = {
     "$live/loaders/state.ts": i2$$$1,
     "$live/loaders/workflows/events.ts": i2$$$2,
     "$live/loaders/workflows/get.ts": i2$$$3,
-    "deco-sites/otica-isabela/loaders/product/productList.ts": $$$0,
-    "deco-sites/otica-isabela/loaders/store/session.ts": $$$1,
+    "deco-sites/otica-isabela/loaders/product/productDetails.ts": $$$0,
+    "deco-sites/otica-isabela/loaders/product/productList.ts": $$$1,
+    "deco-sites/otica-isabela/loaders/store/session.ts": $$$2,
     "deco-sites/std/loaders/linxImpulse/autocompletes/popular.ts": i2$$$4,
     "deco-sites/std/loaders/linxImpulse/autocompletes/suggestions.ts": i2$$$5,
     "deco-sites/std/loaders/linxImpulse/pages/recommendations.ts": i2$$$6,

--- a/loaders/product/productDetails.ts
+++ b/loaders/product/productDetails.ts
@@ -1,0 +1,1 @@
+export { default } from "$store/packs/loaders/productDetails.ts";

--- a/packs/loaders/productDetails.ts
+++ b/packs/loaders/productDetails.ts
@@ -1,0 +1,44 @@
+import { Context } from "$store/packs/accounts/configStore.ts";
+import { ProductData } from "$store/packs/types.ts";
+import paths from "$store/packs/utils/paths.ts";
+import { toProductPage } from "$store/packs/utils/transform.ts";
+import type { ProductDetailsPage } from "deco-sites/std/commerce/types.ts";
+import { fetchAPI } from "deco-sites/std/utils/fetch.ts";
+import type { RequestURLParam } from "deco-sites/std/functions/requestToParam.ts";
+
+export interface Props {
+  slug: RequestURLParam;
+}
+
+/**
+ * @title Otica Isabela Product Details Page
+ * @description works on routes /produto/:slug
+ */
+const loader = async (
+  props: Props,
+  req: Request,
+  ctx: Context,
+): Promise<ProductDetailsPage | null> => {
+  const url = new URL(req.url);
+  const { slug } = props;
+  const { configStore: config } = ctx;
+
+  if (!slug) return null;
+
+  const product = await fetchAPI<ProductData>(
+    paths(config!).product.getProduct({
+      url: slug,
+      offset: 1,
+      ordenacao: "none",
+    }),
+    {
+      method: "POST",
+    },
+  );
+  if (product.Total === 0 && product.produtos.length === 0) {
+    return null;
+  }
+  return toProductPage(product.produtos[0], url.origin);
+};
+
+export default loader;

--- a/packs/loaders/productList.ts
+++ b/packs/loaders/productList.ts
@@ -1,6 +1,6 @@
 import { Context } from "$store/packs/accounts/configStore.ts";
 import {
-  PLPProps as Props,
+  GetProductProps as Props,
   Product as IsabelaProduct,
   ProductData,
 } from "$store/packs/types.ts";
@@ -10,7 +10,7 @@ import type { Product } from "deco-sites/std/commerce/types.ts";
 import { fetchAPI } from "deco-sites/std/utils/fetch.ts";
 
 const loader = async (
-  props: Props,
+  props: Omit<Props, "url">,
   _req: Request,
   ctx: Context,
 ): Promise<Product[] | null> => {

--- a/packs/types.ts
+++ b/packs/types.ts
@@ -133,7 +133,7 @@ export interface Review {
   memberLevel?: string;
 }
 
-export interface PLPProps {
+export interface GetProductProps {
   /**
    * @title Term
    * @description Term to use on search */
@@ -181,6 +181,11 @@ export interface PLPProps {
    * @title Sort
    * @description search sort parameter */
   ordenacao: "none" | "mais-vendidos" | "ofertas" | "menor-preco";
+
+  /**
+   * @title SLUG
+   * @description search by product SLUG */
+  url?: string
 }
 
 export interface DynamicFilter {

--- a/packs/utils/paths.ts
+++ b/packs/utils/paths.ts
@@ -1,5 +1,5 @@
 import { Account } from "$store/packs/accounts/configStore.ts";
-import { PLPProps } from "../types.ts";
+import { GetProductProps } from "../types.ts";
 import { stringfyDynamicFilters } from "./utils.ts";
 
 const paths = ({ token, publicUrl }: Account) => {
@@ -22,7 +22,7 @@ const paths = ({ token, publicUrl }: Account) => {
       initSession: () => href(`${base}/InicioSessao?token=${token}`),
     },
     product: {
-      getProduct: (props: PLPProps) => {
+      getProduct: (props: GetProductProps) => {
         const dynamicFiltersString = stringfyDynamicFilters(
           props.filtrosDinamicos,
         );

--- a/packs/utils/transform.ts
+++ b/packs/utils/transform.ts
@@ -78,10 +78,7 @@ export function toProductPage(
     seo: {
       title: `${product.TituloSeo}`,
       description: `${product.DescricaoSeo}`,
-      canonical: toProductCanonicalUrl(
-        baseURL,
-        product.UrlFriendlyColor,
-      ).href,
+      canonical: "",
     },
   };
 }


### PR DESCRIPTION
## What is this contribution about?

Product details page fully added. It only work with a valid slug, in routes like "/produto/:slug". 

## How to test it?

It can be in two ways:
> Access any product in any shelf - it will work;
> Access the [Deco panel](https://deco.cx/admin/sites/otica-isabela/blocks/new?ref=%23%2Fdefinitions%2FZGVjby1zaXRlcy9vdGljYS1pc2FiZWxhL2xvYWRlcnMvcHJvZHVjdC9wcm9kdWN0RGV0YWlscy50cw%3D%3D&type=product&sidebarMode=edit&tab=0) to see the details of the return. By the way, in the panel, use this config:
![Capturar2](https://github.com/deco-sites/otica-isabela/assets/70353393/f1436a08-3344-4edf-a92d-5a2b9d747286)
I dunno why the panel only works like this, but when you set the option "Get params from request parameters" and try to put the slug in url, it doesn´t work.
But it doesn´t affect the [page functionalities](https://deco.cx/admin/sites/otica-isabela/blocks/Product%20Page?revisionId=31feeda3-da38-4c0d-994e-7ad0097b587c&returnUrl=%2Fadmin%2Fsites%2Fotica-isabela%2Fpages&returnLabel=Pages&path=%252Fproduto%252Farmacao-oculos-feminino-quadrado-preto-1659-isabela-dias&pathTemplate=%252Fproduto%252F%253Aslug&sidebarMode=edit&tab=0)

## Extra info
![Capturar2](https://github.com/deco-sites/otica-isabela/assets/70353393/94d2f58e-887d-4569-beee-dbe9b1bcaa73)
