### PR TITLE
Fix/product panels

### DIFF
--- a/packs/types.ts
+++ b/packs/types.ts
@@ -75,7 +75,7 @@ export interface Product {
   OfertaTermina: string;
   PorcentagemDesconto: number;
   ProdutosMaisCores: ColorVariants[];
-  Paineis: Pannels[];
+  Paineis: Panels[];
   Imagens: Image[];
   ImagemExperimentador: string;
   UrlFriendlyColor: string;
@@ -97,7 +97,7 @@ export interface ColorVariants {
   NomeColor: string;
 }
 
-export interface Pannels {
+export interface Panels {
   IdTipoPainel: number;
   TipoPainel: string;
   Descricao: string;

--- a/packs/utils/transform.ts
+++ b/packs/utils/transform.ts
@@ -1,6 +1,7 @@
 import {
   ColorVariants,
   Image,
+  Panels,
   Product as IsabelaProduct,
   ProductInfo,
 } from "$store/packs/types.ts";
@@ -49,9 +50,8 @@ export function toProduct(product: IsabelaProduct): Product {
     name: Nome.trim(),
     category: toCategory([NomeCategoriaPai, NomeCategoria]),
     sku: `${IdProduct}`,
-    description:
-      Object.values(Paineis).find((p) => p.IdTipoPainel == 11)?.Descricao ??
-        DescricaoSeo,
+    description: Paineis.find((p) => p.IdTipoPainel == 11)?.Descricao ??
+      DescricaoSeo,
     image: productImages.map((image): ImageObject => ({
       "@type": "ImageObject" as const,
       alternateName: Nome,
@@ -61,6 +61,7 @@ export function toProduct(product: IsabelaProduct): Product {
       productsInfo,
       ProdutosMaisCores,
       ImagemExperimentador,
+      Paineis,
     ),
     isVariantOf,
     offers: toAggregateOffer(
@@ -101,6 +102,7 @@ const toAdditionalProperties = (
   properties: ProductInfo[],
   variants: ColorVariants[],
   experimentador: string,
+  panels: Panels[],
 ): PropertyValue[] => {
   const additionalProperties: PropertyValue[] = [];
 
@@ -115,6 +117,13 @@ const toAdditionalProperties = (
       "@type": "PropertyValue" as const,
       "name": item.Nome,
       "value": item.Tipo,
+    })),
+    ...panels.filter(({ IdTipoPainel }) => IdTipoPainel != 11).map((p) => ({
+      "@type": "PropertyValue" as const,
+      "name": p.TipoPainel,
+      "value": p.Descricao,
+      "propertyID": "panel",
+      "unitCode": `${p.IdTipoPainel}`,
     })),
     {
       "@type": "PropertyValue" as const,

--- a/packs/utils/transform.ts
+++ b/packs/utils/transform.ts
@@ -30,6 +30,8 @@ export function toProduct(product: IsabelaProduct): Product {
     NomeCategoria,
     QtdeEstoque,
     OfertaTermina,
+    Paineis,
+    DescricaoSeo,
   } = product;
 
   const productImages = Imagens.map((image: Image) => image.Imagem);
@@ -47,6 +49,9 @@ export function toProduct(product: IsabelaProduct): Product {
     name: Nome.trim(),
     category: toCategory([NomeCategoriaPai, NomeCategoria]),
     sku: `${IdProduct}`,
+    description:
+      Object.values(Paineis).find((p) => p.IdTipoPainel == 11)?.Descricao ??
+        DescricaoSeo,
     image: productImages.map((image): ImageObject => ({
       "@type": "ImageObject" as const,
       alternateName: Nome,


### PR DESCRIPTION
## What is this contribution about?

Fixed inclopete toProduct information: now, it return product description and API panel as additionalProperties

## How to test it?

use [product/productDetails.ts](https://deco.cx/admin/sites/otica-isabela/blocks/?returnLabel=Blocks&returnUrl=%2Fadmin%2Fsites%2Fotica-isabela%2Flibrary&ref=%23%2Fdefinitions%2FZGVjby1zaXRlcy9vdGljYS1pc2FiZWxhL2xvYWRlcnMvcHJvZHVjdC9wcm9kdWN0RGV0YWlscy50cw%3D%3D&type=product) loader, select the option `https://denopkg.com/deco-sites/std@1.21.7/functions/requestToParam.ts@RequestURLParam` in the menu at right, and type a valid product slug

## Extra info
![Capturar](https://github.com/deco-sites/otica-isabela/assets/70353393/fc1887c6-a624-45f7-83bd-ba4a2a2e2fe4)

![Capturar2](https://github.com/deco-sites/otica-isabela/assets/70353393/e01a9d04-9990-442a-a267-45673a90f2ca)


