### PR TITLE
Feat/plpfilters

### DIFF
--- a/packs/constants.ts
+++ b/packs/constants.ts
@@ -17,4 +17,8 @@ export const SORT_OPTIONS: SortOption[] = [
     value: "menor-preco",
     label: "Menor preço",
   },
+  {
+    value: "nome",
+    label: "Nome",
+  },
 ];

--- a/packs/loaders/productListiningPage.ts
+++ b/packs/loaders/productListiningPage.ts
@@ -7,7 +7,6 @@ import {
   ProductData,
 } from "$store/packs/types.ts";
 import paths from "$store/packs/utils/paths.ts";
-import { normalizeFilter } from "$store/packs/utils/utils.ts";
 import type { ProductListingPage } from "deco-sites/std/commerce/types.ts";
 import { fetchAPI } from "deco-sites/std/utils/fetch.ts";
 import { toProductListingPage } from "$store/packs/utils/transform.ts";
@@ -70,16 +69,9 @@ const loaders = async (
     { method: "POST" },
   );
 
-  console.log(path.product.getProduct({
-    offset: 32,
-    IdCategoria: primaryCategory,
-    IdSubCategoria: secondaryCategory,
-    filtrosDinamicos,
-    ...getSearchParams(url),
-  }));
   if (products.produtos.length == 0) return null;
 
-  return toProductListingPage(dynamicFilters, products, category, url);
+  return toProductListingPage(dynamicFilters, products, category, url, filtrosDinamicos);
 };
 
 const getSearchParams = (
@@ -113,8 +105,8 @@ const matchDynamicFilters = (
   url.searchParams.forEach((value, key) => {
     if (!key.startsWith("filter.")) return;
     urlDynamicFilters.push({
-      key: normalizeFilter(key.substring(7)),
-      value: normalizeFilter(value),
+      key: key.substring(7),
+      value: value,
     });
   });
 
@@ -123,9 +115,8 @@ const matchDynamicFilters = (
   return urlDynamicFilters.map((
     { key, value },
   ) => {
-    const filterID = dynamicFiltersAPI.find((value) =>
-      normalizeFilter(value.NomeTipo).startsWith(key)
-    )?.IdTipo!;
+    const filterID = dynamicFiltersAPI.find((value) => value.NomeTipo == key)
+      ?.IdTipo!;
 
     return {
       filterID,

--- a/packs/loaders/productListiningPage.ts
+++ b/packs/loaders/productListiningPage.ts
@@ -2,13 +2,20 @@ import { Context } from "$store/packs/accounts/configStore.ts";
 import {
   APIDynamicFilters,
   Category,
+  DynamicFilter,
   GetProductProps,
   ProductData,
 } from "$store/packs/types.ts";
 import paths from "$store/packs/utils/paths.ts";
+import { normalizeFilter } from "$store/packs/utils/utils.ts";
 import type { ProductListingPage } from "deco-sites/std/commerce/types.ts";
 import { fetchAPI } from "deco-sites/std/utils/fetch.ts";
 import { toProductListingPage } from "$store/packs/utils/transform.ts";
+
+interface UrlDynamicFilters {
+  key: string;
+  value: string;
+}
 
 /**
  * @title Otica Isabela Products Listining Page
@@ -41,29 +48,43 @@ const loaders = async (
     ? [Id, undefined]
     : [IdCategoriaPai, Id];
 
-  const products = await fetchAPI<ProductData>(
-    path.product.getProduct({
-      offset: 32,
-      IdCategoria: primaryCategory,
-      IdSubCategoria: secondaryCategory,
-      ...getSearchParams(url),
-    }),
-    { method: "POST" },
-  );
-
-  if (products.produtos.length == 0) return null;
-
   const dynamicFilters = await fetchAPI<APIDynamicFilters[]>(
-    path.dynamicFillter.getDynamicFillters(
+    path.dynamicFilter.getDynamicFilters(
       secondaryCategory ?? primaryCategory,
     ),
     { method: "POST" },
   );
 
+  const filtrosDinamicos = dynamicFilters.length > 0
+    ? matchDynamicFilters(url, dynamicFilters)
+    : undefined;
+
+  const products = await fetchAPI<ProductData>(
+    path.product.getProduct({
+      offset: 32,
+      IdCategoria: primaryCategory,
+      IdSubCategoria: secondaryCategory,
+      filtrosDinamicos,
+      ...getSearchParams(url),
+    }),
+    { method: "POST" },
+  );
+
+  console.log(path.product.getProduct({
+    offset: 32,
+    IdCategoria: primaryCategory,
+    IdSubCategoria: secondaryCategory,
+    filtrosDinamicos,
+    ...getSearchParams(url),
+  }));
+  if (products.produtos.length == 0) return null;
+
   return toProductListingPage(dynamicFilters, products, category, url);
 };
 
-const getSearchParams = (url: URL): Omit<GetProductProps, "offset"> => {
+const getSearchParams = (
+  url: URL,
+): Omit<GetProductProps, "offset"> => {
   const allowedProducts: string[] = [
     "none",
     "mais-vendidos",
@@ -76,10 +97,43 @@ const getSearchParams = (url: URL): Omit<GetProductProps, "offset"> => {
     allowedProducts.find((value) => value == url.searchParams.get("sort")) ??
       "nome";
   const page = url.searchParams.get("page") ?? 1;
+
   return {
     ordenacao: ordenacao as GetProductProps["ordenacao"],
     page: Number(page),
   };
+};
+
+const matchDynamicFilters = (
+  url: URL,
+  dynamicFiltersAPI: APIDynamicFilters[],
+): DynamicFilter[] | undefined => {
+  const urlDynamicFilters: UrlDynamicFilters[] = [];
+
+  url.searchParams.forEach((value, key) => {
+    if (!key.startsWith("filter.")) return;
+    urlDynamicFilters.push({
+      key: normalizeFilter(key.substring(7)),
+      value: normalizeFilter(value),
+    });
+  });
+
+  if (urlDynamicFilters.length == 0) return undefined;
+
+  return urlDynamicFilters.map((
+    { key, value },
+  ) => {
+    const filterID = dynamicFiltersAPI.find((value) =>
+      normalizeFilter(value.NomeTipo).startsWith(key)
+    )?.IdTipo!;
+
+    return {
+      filterID,
+      filterValue: value,
+    };
+  }).filter(({ filterID, filterValue }) =>
+    filterID !== undefined && filterValue !== undefined
+  );
 };
 
 export default loaders;

--- a/packs/loaders/productListiningPage.ts
+++ b/packs/loaders/productListiningPage.ts
@@ -73,7 +73,7 @@ const loaders = async (
     { method: "POST" },
   );
 
-  if (products.produtos.length == 0) return null;
+  if (!products.produtos.length) return null;
 
   return toProductListingPage(
     {

--- a/packs/loaders/productListiningPage.ts
+++ b/packs/loaders/productListiningPage.ts
@@ -48,7 +48,7 @@ const loaders = async (
   const url = new URL(req.url);
   const path = paths(config!);
 
-  const isCategoryPage = url.pathname.split("/")[1] != "busca";
+  const isCategoryPage = !url.pathname.includes("busca");
 
   const pageParams: PLPPageParams | null = isCategoryPage
     ? await getCategoryPageParams(url, config!).then((data) => data)

--- a/packs/loaders/productListiningPage.ts
+++ b/packs/loaders/productListiningPage.ts
@@ -71,7 +71,13 @@ const loaders = async (
 
   if (products.produtos.length == 0) return null;
 
-  return toProductListingPage(dynamicFilters, products, category, url, filtrosDinamicos);
+  return toProductListingPage(
+    dynamicFilters,
+    products,
+    category,
+    url,
+    filtrosDinamicos,
+  );
 };
 
 const getSearchParams = (

--- a/packs/types.ts
+++ b/packs/types.ts
@@ -1,3 +1,5 @@
+import type { Filter, ListItem, Seo } from "deco-sites/std/commerce/types.ts";
+
 export type Session = {
   SessionCustomer: SessionCustomer;
 };
@@ -168,7 +170,7 @@ export interface GetProductProps {
 
   /**
    * @title Dynamic filters
-   * @description Define dinamic filters for the query. Example: Aro Fechado,Retangular */
+   * @description Define dinamic filters for the query. Its not possible to use them with "Term" parameter in "productList" and "ProductListiningPage" Loaders */
 
   filtrosDinamicos?: DynamicFilter[];
 
@@ -233,4 +235,20 @@ export interface APIDynamicFilters {
   h1: string;
   h2: string;
   h3: string;
+}
+
+export interface ProductListiningPageProps {
+  productsData: ProductData;
+  baseURL: URL;
+  pageType: "category" | "search";
+  category?: Category;
+  filtersApi?: APIDynamicFilters[];
+  filtersUrl?: DynamicFilter[] | undefined;
+  term?: string;
+}
+
+export interface PLPPageProps {
+  itemListElement: ListItem<string>[];
+  filters: Filter[] | [];
+  seo: Seo;
 }

--- a/packs/types.ts
+++ b/packs/types.ts
@@ -170,7 +170,7 @@ export interface GetProductProps {
 
   /**
    * @title Dynamic filters
-   * @description Define dinamic filters for the query. Its not possible to use them with "Term" parameter in "productList" and "ProductListiningPage" Loaders */
+   * @description Define dinamic filters for the query. Its not possible to use them with "Term" parameter */
 
   filtrosDinamicos?: DynamicFilter[];
 

--- a/packs/utils/paths.ts
+++ b/packs/utils/paths.ts
@@ -2,11 +2,6 @@ import { Account } from "$store/packs/accounts/configStore.ts";
 import { GetProductProps } from "../types.ts";
 import { stringfyDynamicFilters } from "./utils.ts";
 
-interface APIDynamicFiltersURL {
-  primaryCategory?: number;
-  secondaryCategory?: number;
-}
-
 const paths = ({ token, publicUrl }: Account) => {
   const base = `${publicUrl}Api`;
   const href = (path: string, extraParams?: object) => {
@@ -42,8 +37,8 @@ const paths = ({ token, publicUrl }: Account) => {
       getCategory: (categoryUrl: string) =>
         href(`${base}/Categorias?token=${token}`, { url: categoryUrl }),
     },
-    dynamicFillter: {
-      getDynamicFillters: (category: number) =>
+    dynamicFilter: {
+      getDynamicFilters: (category: number) =>
         href(`${base}/FiltrosDinamicos?token=${token}`, {
           idCategoria: category,
         }),

--- a/packs/utils/transform.ts
+++ b/packs/utils/transform.ts
@@ -2,6 +2,7 @@ import {
   APIDynamicFilters,
   Category,
   ColorVariants,
+  DynamicFilter,
   Image,
   Panels,
   Product as IsabelaProduct,
@@ -269,10 +270,11 @@ const toProductCanonicalUrl = (
 ): URL => new URL(`/produto/${productSlug}`, baseURL);
 
 export const toProductListingPage = (
-  filters: APIDynamicFilters[],
+  filtersApi: APIDynamicFilters[],
   productsData: IsabelaProductData,
   category: Category,
   baseURL: URL,
+  filtersUrl: DynamicFilter[] | undefined,
 ): ProductListingPage => {
   const { produtos } = productsData;
   const itemListElement = toPageBreadcrumbList(baseURL, category.Nome);
@@ -283,13 +285,13 @@ export const toProductListingPage = (
       itemListElement,
       numberOfItems: itemListElement.length,
     },
-    filters: groupPageFilters(filters).map((f) => ({
+    filters: groupPageFilters(filtersApi).map((f) => ({
       "@type": "FilterToggle",
       key: `${f[0].IdTipo}`,
       label: f[0].NomeTipo,
       quantity: countPageFiltersQuantity(produtos, "typeId", f[0].IdTipo),
       values: f.map((individualFilter) =>
-        toPageFilterValues(individualFilter, produtos)
+        toPageFilterValues(individualFilter, produtos, filtersUrl)
       ),
     })),
     products: produtos.map((product) => toProduct(product)),
@@ -304,11 +306,11 @@ export const toProductListingPage = (
 };
 
 const groupPageFilters = (
-  filters: APIDynamicFilters[],
+  filtersApi: APIDynamicFilters[],
 ): APIDynamicFilters[][] => {
   const orderedFilters: APIDynamicFilters[][] = [];
 
-  filters.forEach((filter) => {
+  filtersApi.forEach((filter) => {
     const { IdTipo } = filter;
     orderedFilters[IdTipo] = orderedFilters[IdTipo] ?? [];
     orderedFilters[IdTipo].push(filter);
@@ -318,18 +320,23 @@ const groupPageFilters = (
 };
 
 const toPageFilterValues = (
-  filter: APIDynamicFilters,
+  filterApi: APIDynamicFilters,
   products: IsabelaProduct[],
+  filtersUrl: DynamicFilter[] | undefined,
 ): FilterToggleValue => ({
   quantity: countPageFiltersQuantity(
     products,
     "typeValue",
-    filter.IdTipo,
-    filter.Nome,
+    filterApi.IdTipo,
+    filterApi.Nome,
   ),
-  label: filter.Nome,
-  value: filter.Nome,
-  selected: false,
+  label: filterApi.Nome,
+  value: filterApi.Nome,
+  selected: !filtersUrl ? false : filtersUrl.some(
+    (filter) =>
+      filter.filterID === filterApi.IdTipo &&
+      filter.filterValue === filterApi.Nome,
+  ),
   url: "",
 });
 

--- a/packs/utils/transform.ts
+++ b/packs/utils/transform.ts
@@ -295,7 +295,7 @@ export const toProductListingPage = (
       ),
     })),
     products: produtos.map((product) => toProduct(product)),
-    pageInfo: toPageInfo(productsData),
+    pageInfo: toPageInfo(productsData, baseURL.searchParams),
     sortOptions: SORT_OPTIONS,
     seo: {
       title: category.Title_SEO,
@@ -340,13 +340,28 @@ const toPageFilterValues = (
   url: "",
 });
 
-const toPageInfo = ({ Total, Pagina, Offset }: IsabelaProductData) => {
+const toPageInfo = (
+  { Total, Pagina, Offset }: IsabelaProductData,
+  params: URLSearchParams,
+) => {
   const totalPages = Math.ceil(Total / Offset);
-  const nextPage = totalPages > Pagina ? `?page=${Pagina + 1}` : undefined;
-  const previousPage = Pagina > 1 ? `?page=${Pagina - 1}` : undefined;
+
+  const hasNextPage = totalPages > Pagina;
+  const hasPreviousPage = Pagina > 1;
+  const nextPage = new URLSearchParams(params);
+  const previousPage = new URLSearchParams(params);
+
+  if (hasNextPage) {
+    nextPage.set("page", (Pagina + 1).toString());
+  }
+
+  if (hasPreviousPage) {
+    previousPage.set("page", (Pagina - 1).toString());
+  }
+
   return {
-    nextPage,
-    previousPage,
+    nextPage: hasNextPage ? `?${nextPage}` : undefined,
+    previousPage: hasPreviousPage ? `?${previousPage}` : undefined,
     currentPage: Pagina - 1,
     records: Total,
     recordPerPage: Offset,

--- a/packs/utils/transform.ts
+++ b/packs/utils/transform.ts
@@ -1,13 +1,14 @@
 import {
   APIDynamicFilters,
-  Category,
   ColorVariants,
   DynamicFilter,
   Image,
   Panels,
+  PLPPageProps,
   Product as IsabelaProduct,
   ProductData as IsabelaProductData,
   ProductInfo,
+  ProductListiningPageProps,
 } from "$store/packs/types.ts";
 import type {
   AggregateOffer,
@@ -22,6 +23,12 @@ import type {
   PropertyValue,
 } from "deco-sites/std/commerce/types.ts";
 import { SORT_OPTIONS } from "deco-sites/otica-isabela/packs/constants.ts";
+
+type CategoryPageProps =
+  & Required<
+    Omit<ProductListiningPageProps, "pageType" | "term" | "filtersUrl">
+  >
+  & { filtersUrl: DynamicFilter[] | undefined };
 
 export function toProduct(product: IsabelaProduct): Product {
   const {
@@ -269,15 +276,25 @@ const toProductCanonicalUrl = (
   productSlug: string,
 ): URL => new URL(`/produto/${productSlug}`, baseURL);
 
+//<<---- ProductListiningPage ---->>
+
 export const toProductListingPage = (
-  filtersApi: APIDynamicFilters[],
-  productsData: IsabelaProductData,
-  category: Category,
-  baseURL: URL,
-  filtersUrl: DynamicFilter[] | undefined,
+  props: ProductListiningPageProps,
 ): ProductListingPage => {
+  const { productsData, pageType, baseURL } = props;
   const { produtos } = productsData;
-  const itemListElement = toPageBreadcrumbList(baseURL, category.Nome);
+  const { itemListElement, filters, seo } = pageType == "category"
+    ? categoryPageProps(
+      {
+        baseURL,
+        category: props.category!,
+        filtersApi: props.filtersApi!,
+        filtersUrl: props.filtersUrl,
+        productsData,
+      },
+    )
+    : searchPageProps(baseURL, props.term!);
+
   return {
     "@type": "ProductListingPage",
     breadcrumb: {
@@ -285,6 +302,21 @@ export const toProductListingPage = (
       itemListElement,
       numberOfItems: itemListElement.length,
     },
+    filters,
+    products: produtos.map((product) => toProduct(product)),
+    pageInfo: toPageInfo(productsData, baseURL.searchParams),
+    sortOptions: SORT_OPTIONS,
+    seo,
+  };
+};
+
+const categoryPageProps = (
+  props: CategoryPageProps,
+): PLPPageProps => {
+  const { productsData, baseURL, category, filtersApi, filtersUrl } = props;
+  const { produtos } = productsData;
+  return {
+    itemListElement: toPageBreadcrumbList(baseURL, category.Nome),
     filters: groupPageFilters(filtersApi).map((f) => ({
       "@type": "FilterToggle",
       key: `${f[0].IdTipo}`,
@@ -294,16 +326,31 @@ export const toProductListingPage = (
         toPageFilterValues(individualFilter, produtos, filtersUrl)
       ),
     })),
-    products: produtos.map((product) => toProduct(product)),
-    pageInfo: toPageInfo(productsData, baseURL.searchParams),
-    sortOptions: SORT_OPTIONS,
     seo: {
-      title: category.Title_SEO,
-      description: category.PageDescription_SEO ?? category.Description_SEO,
+      title: category!.Title_SEO,
+      description: category!.PageDescription_SEO ?? category!.Description_SEO,
       canonical: "",
     },
   };
 };
+
+const searchPageProps = (url: URL, term: string): PLPPageProps => ({
+  itemListElement: [{
+    "@type": "ListItem" as const,
+    name: term.toUpperCase(),
+    item: new URL(
+      `?termo=${term}`,
+      url.origin,
+    ).href,
+    position: 1,
+  }],
+  filters: [],
+  seo: {
+    title: "",
+    description: "",
+    canonical: "",
+  },
+});
 
 const groupPageFilters = (
   filtersApi: APIDynamicFilters[],

--- a/packs/utils/transform.ts
+++ b/packs/utils/transform.ts
@@ -339,7 +339,7 @@ const searchPageProps = (url: URL, term: string): PLPPageProps => ({
     "@type": "ListItem" as const,
     name: term.toUpperCase(),
     item: new URL(
-      `?termo=${term}`,
+      `/busca?termo=${term}`,
       url.origin,
     ).href,
     position: 1,

--- a/packs/utils/utils.ts
+++ b/packs/utils/utils.ts
@@ -11,24 +11,3 @@ export const stringfyDynamicFilters = (dynamicFilters?: DynamicFilter[]) => {
       .join(","),
   }).toString();
 };
-
-export const normalizeFilter = (value: string) => {
-  const exceptions = ["da", "de", "do"]; // Palavras que não devem ter a primeira letra em maiúsculo
-
-  const capitalizeWord = (word: string) => {
-    return exceptions.includes(word.toLowerCase())
-      ? word.charAt(0).toLowerCase() + word.slice(1) // Mantém a palavra em minúsculas se for uma exceção
-      : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
-  };
-
-  return value
-    .toLowerCase()
-    .trim()
-    .replace(/[_.-]/g, " ")
-    .split(" ")
-    .map((
-      word,
-      index,
-    ) => (index === 0 ? capitalizeWord(word) : capitalizeWord(word)))
-    .join(" ");
-};

--- a/packs/utils/utils.ts
+++ b/packs/utils/utils.ts
@@ -11,3 +11,24 @@ export const stringfyDynamicFilters = (dynamicFilters?: DynamicFilter[]) => {
       .join(","),
   }).toString();
 };
+
+export const normalizeFilter = (value: string) => {
+  const exceptions = ["da", "de", "do"]; // Palavras que não devem ter a primeira letra em maiúsculo
+
+  const capitalizeWord = (word: string) => {
+    return exceptions.includes(word.toLowerCase())
+      ? word.charAt(0).toLowerCase() + word.slice(1) // Mantém a palavra em minúsculas se for uma exceção
+      : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+  };
+
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[_.-]/g, " ")
+    .split(" ")
+    .map((
+      word,
+      index,
+    ) => (index === 0 ? capitalizeWord(word) : capitalizeWord(word)))
+    .join(" ");
+};


### PR DESCRIPTION
## What is this contribution about?

PLP filters added. Now, is possible to fillter the PLP products by filters in url. Should follow the pattern                                         `?filters.$FilterName=FilterValue`

## How to test it?

Use [product/productListiningPage.ts](https://deco.cx/admin/sites/otica-isabela/blocks/?returnLabel=Blocos&returnUrl=%2Fadmin%2Fsites%2Fotica-isabela%2Flibrary&ref=%23%2Fdefinitions%2FZGVjby1zaXRlcy9vdGljYS1pc2FiZWxhL2xvYWRlcnMvcHJvZHVjdC9wcm9kdWN0TGlzdGluaW5nUGFnZS50cw%3D%3D&type=product) in Deco panel or access http://localhost:8000/mycategory and define some filters in querystring. Use the pattern `?filters.$FilterName=FilterValue`

## Extra info

![Capturar](https://github.com/deco-sites/otica-isabela/assets/70353393/b1d6e663-e937-42c5-bb87-2438a85b97dd)

![Capturar](https://github.com/deco-sites/otica-isabela/assets/70353393/4d93c147-22aa-4c2a-9bba-b2b8292adfbc)


