### PR TITLE
feat(packs): get testimonials loader added

### DIFF
--- a/components/ui/TestimonialItem.tsx
+++ b/components/ui/TestimonialItem.tsx
@@ -11,13 +11,15 @@ export interface MembershipBadgeProps {
   badgeDescription: string;
 }
 
-export const UserInfos = (
-  { authorName, ratingValue, membershipBadge }: {
-    authorName: string;
-    ratingValue: number;
-    membershipBadge?: MembershipBadgeProps;
-  },
-) => {
+export const UserInfos = ({
+  authorName,
+  ratingValue,
+  membershipBadge,
+}: {
+  authorName: string;
+  ratingValue: number;
+  membershipBadge?: MembershipBadgeProps;
+}) => {
   const { badgeDescription, bagde } = membershipBadge ?? {};
   const { desktop, mobile } = bagde ?? {};
 
@@ -39,10 +41,7 @@ export const UserInfos = (
               width={68}
               height={75}
             />
-            <img
-              src={mobile ?? desktop}
-              alt={badgeDescription}
-            />
+            <img src={mobile ?? desktop} alt={badgeDescription} />
           </Picture>
         )}
       </p>
@@ -62,15 +61,13 @@ export const UserInfos = (
   );
 };
 
-const TestimonialItem = (
-  {
-    membershipBadges,
-    review,
-  }: {
-    review: Review;
-    membershipBadges?: MembershipBadgeProps[];
-  },
-) => {
+const TestimonialItem = ({
+  membershipBadges,
+  review,
+}: {
+  review: Review;
+  membershipBadges?: MembershipBadgeProps[];
+}) => {
   const {
     additionalImage,
     authorCity,
@@ -84,8 +81,8 @@ const TestimonialItem = (
   } = review;
 
   const id = useId();
-  const memberBadge = membershipBadges?.find((item) =>
-    item.label === memberLevel
+  const memberBadge = membershipBadges?.find(
+    (item) => item.label === memberLevel
   );
 
   const descriptionSplit = reviewDescription.split(" ");
@@ -97,13 +94,15 @@ const TestimonialItem = (
     <div class="flex flex-col items-center text-center border border-blue-300 rounded-xl px-3 py-5 ">
       <div class="flex items-start justify-center gap-x-2 ">
         <div class="w-1/3 flex flex-col">
-          <Image
-            src={additionalImage}
-            alt={productName}
-            width={140}
-            class="rounded-xl w-full"
-            height={200}
-          />
+          {additionalImage && (
+            <Image
+              src={additionalImage}
+              alt={productName}
+              width={140}
+              class="rounded-xl w-full"
+              height={200}
+            />
+          )}
 
           <div class="flex flex-col items-start">
             <span class="text-sm  text-blue-200 flex items-center justify-center gap-x-2 font-semibold mt-3 ">

--- a/live.gen.ts
+++ b/live.gen.ts
@@ -8,7 +8,8 @@ import * as $$$1 from "./loaders/product/productDetails.ts";
 import * as $$$2 from "./loaders/product/productList.ts";
 import * as $$$3 from "./loaders/product/productListiningPage.ts";
 import * as $$$4 from "./loaders/product/suggestions.ts";
-import * as $$$5 from "./loaders/store/session.ts";
+import * as $$$5 from "./loaders/product/testimonials.ts";
+import * as $$$6 from "./loaders/store/session.ts";
 import * as $$$$0 from "./routes/live/invoke/_middleware.tsx";
 import * as $$$$1 from "./routes/styles.css.ts";
 import * as $$$$2 from "./routes/_app.tsx";
@@ -232,7 +233,8 @@ const manifest = {
     "deco-sites/otica-isabela/loaders/product/productList.ts": $$$2,
     "deco-sites/otica-isabela/loaders/product/productListiningPage.ts": $$$3,
     "deco-sites/otica-isabela/loaders/product/suggestions.ts": $$$4,
-    "deco-sites/otica-isabela/loaders/store/session.ts": $$$5,
+    "deco-sites/otica-isabela/loaders/product/testimonials.ts": $$$5,
+    "deco-sites/otica-isabela/loaders/store/session.ts": $$$6,
     "deco-sites/std/loaders/linxImpulse/autocompletes/popular.ts": i2$$$4,
     "deco-sites/std/loaders/linxImpulse/autocompletes/suggestions.ts": i2$$$5,
     "deco-sites/std/loaders/linxImpulse/pages/recommendations.ts": i2$$$6,

--- a/loaders/product/testimonials.ts
+++ b/loaders/product/testimonials.ts
@@ -1,0 +1,1 @@
+export { default } from "$store/packs/loaders/testimonials.ts";

--- a/packs/loaders/testimonials.ts
+++ b/packs/loaders/testimonials.ts
@@ -20,6 +20,11 @@ export interface Props {
    * @title Offset
    * @default 9 */
   offset?: number;
+
+  /**
+   * @title Only With Photos
+   */
+  somenteFoto?: boolean;
 }
 
 /**
@@ -34,12 +39,14 @@ const loader = async (
 ): Promise<Review[] | null> => {
   const { configStore: config } = ctx;
   const path = paths(config!);
-  const { slug, ordenacao, offset } = props;
+  const { slug, ordenacao, offset, somenteFoto } = props;
   const url = new URL(req.url);
 
-  const idproduto = await getProductIdBySlug(
-    path.product.getProduct({ offset: 1, ordenacao: "none", url: slug }),
-  );
+  const idproduto = slug
+    ? await getProductIdBySlug(
+      path.product.getProduct({ offset: 1, ordenacao: "none", url: slug }),
+    )
+    : undefined;
 
   if (slug && !idproduto) return null;
 
@@ -47,6 +54,7 @@ const loader = async (
     path.testimonials.getTestimonials({
       ordenacao: ordenacao ?? "ultimosAdicionados",
       offset: offset ?? 9,
+      somenteFoto: somenteFoto ?? false,
       idproduto,
     }),
     {

--- a/packs/loaders/testimonials.ts
+++ b/packs/loaders/testimonials.ts
@@ -4,18 +4,31 @@ import {
   APIGetTestimonials,
   ProductData,
   Review,
-  TestimonialProps,
 } from "deco-sites/otica-isabela/packs/types.ts";
 import { fetchAPI } from "deco-sites/std/utils/fetch.ts";
 import { toReview } from "deco-sites/otica-isabela/packs/utils/transform.ts";
+import type { RequestURLParam } from "deco-sites/std/functions/requestToParam.ts";
+
+export interface Props {
+  slug?: RequestURLParam;
+  /**
+   * @title Sort
+   * @description search sort parameter */
+  ordenacao?: "ultimosAdicionados" | "none";
+
+  /**
+   * @title Offset
+   * @default 9 */
+  offset?: number;
+}
 
 /**
-@title Otica Isabela Dias Testimonials getter
-@description This loader gets testimonials from store customers. It can be used to get testimonials from a specific product or all tertimonials
-**/
+ * @title Otica Isabela Dias - Testimonials
+ * @description This loader gets testimonials from store customers. It can be used to get testimonials from a specific product or all testimonials
+ */
 
 const loader = async (
-  props: TestimonialProps,
+  props: Props,
   req: Request,
   ctx: Context,
 ): Promise<Review[] | null> => {
@@ -24,11 +37,9 @@ const loader = async (
   const { slug, ordenacao, offset } = props;
   const url = new URL(req.url);
 
-  const idproduto = slug
-    ? await getProductIdBySlug(
-      path.product.getProduct({ offset: 1, ordenacao: "none", url: slug }),
-    )
-    : undefined;
+  const idproduto = await getProductIdBySlug(
+    path.product.getProduct({ offset: 1, ordenacao: "none", url: slug }),
+  );
 
   if (slug && !idproduto) return null;
 

--- a/packs/loaders/testimonials.ts
+++ b/packs/loaders/testimonials.ts
@@ -1,0 +1,61 @@
+import { Context } from "$store/packs/accounts/configStore.ts";
+import paths from "$store/packs/utils/paths.ts";
+import {
+  APIGetTestimonials,
+  ProductData,
+  Review,
+  TestimonialProps,
+} from "deco-sites/otica-isabela/packs/types.ts";
+import { fetchAPI } from "deco-sites/std/utils/fetch.ts";
+import { toReview } from "deco-sites/otica-isabela/packs/utils/transform.ts";
+
+/**
+@title Otica Isabela Dias Testimonials getter
+@description This loader gets testimonials from store customers. It can be used to get testimonials from a specific product or all tertimonials
+**/
+
+const loader = async (
+  props: TestimonialProps,
+  req: Request,
+  ctx: Context,
+): Promise<Review[] | null> => {
+  const { configStore: config } = ctx;
+  const path = paths(config!);
+  const { slug, ordenacao, offset } = props;
+  const url = new URL(req.url);
+
+  const idproduto = slug
+    ? await getProductIdBySlug(
+      path.product.getProduct({ offset: 1, ordenacao: "none", url: slug }),
+    )
+    : undefined;
+
+  if (slug && !idproduto) return null;
+
+  const testimonials = await fetchAPI<APIGetTestimonials[]>(
+    path.testimonials.getTestimonials({
+      ordenacao: ordenacao ?? "ultimosAdicionados",
+      offset: offset ?? 9,
+      idproduto,
+    }),
+    {
+      method: "POST",
+    },
+  );
+
+  if (!testimonials.length) return null;
+
+  return testimonials.map((testimonial) => toReview(testimonial, url));
+};
+
+const getProductIdBySlug = async (
+  path: string,
+): Promise<number | undefined> => {
+  const product = await fetchAPI<ProductData>(path, {
+    method: "POST",
+  });
+
+  return product.Total ? product.produtos[0].IdProduct : undefined;
+};
+
+export default loader;

--- a/packs/types.ts
+++ b/packs/types.ts
@@ -1,4 +1,5 @@
 import type { Filter, ListItem, Seo } from "deco-sites/std/commerce/types.ts";
+import type { RequestURLParam } from "deco-sites/std/functions/requestToParam.ts";
 
 export type Session = {
   SessionCustomer: SessionCustomer;
@@ -40,18 +41,6 @@ export interface ProductData {
   Pagina: number;
   Offset: number;
   produtos: Product[];
-}
-
-export interface Review {
-  ratingValue: number;
-  authorName: string;
-  reviewDescription: string;
-  authorCity: string;
-  productName: string;
-  productPhoto: string;
-  productLink: string;
-  additionalImage: string;
-  memberLevel?: string;
 }
 
 export interface Product {
@@ -290,4 +279,34 @@ export interface ProductsCart {
 
 export interface OrderForm {
   products: ProductsCart[];
+}
+
+export interface TestimonialProps {
+  slug?: RequestURLParam;
+  /**
+   * @title Sort
+   * @description search sort parameter */
+  ordenacao?: "ultimosAdicionados" | "none";
+
+  /**
+   * @title Offset
+   * @default 9 */
+  offset?: number;
+}
+
+export interface APIGetTestimonials {
+  IdOrderProductComments: number;
+  IdOrder: number;
+  CommentsImgPath: string;
+  Stars: number;
+  NameCustomer: string;
+  CustomerAddress: string;
+  CommentsPhrase: string;
+  Comments: string;
+  UrlFriendly: string;
+  ImagePath: string;
+  NameProduct: string;
+  StampImagePath: string;
+  Index: number;
+  IdProduto: number;
 }

--- a/packs/types.ts
+++ b/packs/types.ts
@@ -1,5 +1,4 @@
 import type { Filter, ListItem, Seo } from "deco-sites/std/commerce/types.ts";
-import type { RequestURLParam } from "deco-sites/std/functions/requestToParam.ts";
 
 export type Session = {
   SessionCustomer: SessionCustomer;
@@ -279,19 +278,6 @@ export interface ProductsCart {
 
 export interface OrderForm {
   products: ProductsCart[];
-}
-
-export interface TestimonialProps {
-  slug?: RequestURLParam;
-  /**
-   * @title Sort
-   * @description search sort parameter */
-  ordenacao?: "ultimosAdicionados" | "none";
-
-  /**
-   * @title Offset
-   * @default 9 */
-  offset?: number;
 }
 
 export interface APIGetTestimonials {

--- a/packs/utils/paths.ts
+++ b/packs/utils/paths.ts
@@ -1,5 +1,5 @@
 import { Account } from "$store/packs/accounts/configStore.ts";
-import { GetProductProps, TestimonialProps } from "../types.ts";
+import { GetProductProps } from "../types.ts";
 import { stringfyDynamicFilters } from "./utils.ts";
 
 const paths = ({ token, publicUrl }: Account) => {
@@ -51,7 +51,11 @@ const paths = ({ token, publicUrl }: Account) => {
     },
     testimonials: {
       getTestimonials: (
-        props: Omit<TestimonialProps, "slug"> & { idproduto?: number },
+        props: {
+          idproduto?: number;
+          ordenacao?: "ultimosAdicionados" | "none";
+          offset?: number;
+        },
       ) => href(`${base}/Depoimentos?token=${token}`, props),
     },
   };

--- a/packs/utils/paths.ts
+++ b/packs/utils/paths.ts
@@ -1,5 +1,5 @@
 import { Account } from "$store/packs/accounts/configStore.ts";
-import { GetProductProps } from "../types.ts";
+import { GetProductProps, TestimonialProps } from "../types.ts";
 import { stringfyDynamicFilters } from "./utils.ts";
 
 const paths = ({ token, publicUrl }: Account) => {
@@ -48,6 +48,11 @@ const paths = ({ token, publicUrl }: Account) => {
         href(`${base}/DadosCarrinho?token=${token}`, {
           idClienteSessao: clientId,
         }),
+    },
+    testimonials: {
+      getTestimonials: (
+        props: Omit<TestimonialProps, "slug"> & { idproduto?: number },
+      ) => href(`${base}/Depoimentos?token=${token}`, props),
     },
   };
 };

--- a/packs/utils/paths.ts
+++ b/packs/utils/paths.ts
@@ -1,6 +1,7 @@
 import { Account } from "$store/packs/accounts/configStore.ts";
 import { GetProductProps } from "../types.ts";
 import { stringfyDynamicFilters } from "./utils.ts";
+import { Props as TestimonialProps } from "$store/packs/loaders/testimonials.ts";
 
 const paths = ({ token, publicUrl }: Account) => {
   const base = `${publicUrl}Api`;
@@ -51,10 +52,8 @@ const paths = ({ token, publicUrl }: Account) => {
     },
     testimonials: {
       getTestimonials: (
-        props: {
+        props: Omit<TestimonialProps, "slug"> & {
           idproduto?: number;
-          ordenacao?: "ultimosAdicionados" | "none";
-          offset?: number;
         },
       ) => href(`${base}/Depoimentos?token=${token}`, props),
     },

--- a/packs/utils/transform.ts
+++ b/packs/utils/transform.ts
@@ -1,5 +1,6 @@
 import {
   APIDynamicFilters,
+  APIGetTestimonials,
   Category,
   ColorVariants,
   DynamicFilter,
@@ -10,6 +11,7 @@ import {
   ProductData as IsabelaProductData,
   ProductInfo,
   ProductListiningPageProps,
+  Review,
 } from "$store/packs/types.ts";
 import type {
   AggregateOffer,
@@ -450,3 +452,26 @@ const countPageFiltersQuantity = (
       })
     )
     .length;
+
+export const toReview = (testimonial: APIGetTestimonials, url: URL): Review => {
+  const {
+    Stars,
+    NameCustomer,
+    Comments,
+    CustomerAddress,
+    NameProduct,
+    ImagePath,
+    UrlFriendly,
+    CommentsImgPath,
+  } = testimonial;
+  return {
+    ratingValue: Stars,
+    authorName: NameCustomer,
+    reviewDescription: Comments,
+    authorCity: CustomerAddress,
+    productName: NameProduct,
+    productPhoto: ImagePath,
+    productLink: `${url.origin}/produto/${UrlFriendly}`,
+    additionalImage: CommentsImgPath,
+  };
+};

--- a/sections/Content/Testimonials.tsx
+++ b/sections/Content/Testimonials.tsx
@@ -6,10 +6,9 @@ import SliderJS from "$store/islands/SliderJS.tsx";
 import { useId } from "preact/hooks";
 import TestimonialItem from "$store/components/ui/TestimonialItem.tsx";
 
-import type {
-  MembershipBadgeProps,
-} from "$store/components/ui/TestimonialItem.tsx";
+import type { MembershipBadgeProps } from "$store/components/ui/TestimonialItem.tsx";
 import { Review } from "deco-sites/otica-isabela/packs/types.ts";
+import type { LoaderReturnType } from "$live/types.ts";
 
 export interface Props {
   header?: IconTitleProps;
@@ -18,70 +17,19 @@ export interface Props {
    * @description Utilize o campo label em Membership Badges para adicionar a classificação do cliente.
    */
   membershipBadges?: MembershipBadgeProps[];
+  page: LoaderReturnType<Review[] | null>;
 }
 
-const REVIEW_MOCK: Review[] = [
-  {
-    additionalImage:
-      "https://www.oticaisabeladias.com.br//Images/Blob/Avaliacoes//876231b79dc743c1860a4b7e8d3d8cc7.webp",
-    authorCity: "Florianópolis - SC",
-    authorName: "Maria Fernanda",
-    productLink:
-      "/produto/Armacao-Oculos-Clipon-Grau-Feminino-1271-Isabela-Dias",
-    productName: "Óculos Clipon Redondo Feminino 1271",
-    productPhoto:
-      "https://www.oticaisabeladias.com.br/backoffice//Images/Blob/webp_id//53f3483dfa624952aff955a695e069d9-2.webp",
-    ratingValue: 5,
-    reviewDescription:
-      "Os óculos chegaram bem rápido (pedi Sedex) e bem embalados, o que era uma das minhas maiores preocupações. Eles foram elogiados pela pessoa mais importantes, minha oftalmologista! Ela disse que ficaram muito bons e realmente, mesmo sendo um grau maior minha lente ficou mais fina que a anterior. As lentes clip-on são muito estilosas também. Recomendo 100%",
-  },
-  {
-    additionalImage:
-      "https://www.oticaisabeladias.com.br//Images/Blob/Avaliacoes//876231b79dc743c1860a4b7e8d3d8cc7.webp",
-    authorCity: "Florianópolis - SC",
-    authorName: "Maria Fernanda",
-    productLink:
-      "/produto/Armacao-Oculos-Clipon-Grau-Feminino-1271-Isabela-Dias",
-    productName: "Óculos Clipon Redondo Feminino 1271",
-    productPhoto:
-      "https://www.oticaisabeladias.com.br/backoffice//Images/Blob/webp_id//53f3483dfa624952aff955a695e069d9-2.webp",
-    ratingValue: 5,
-    reviewDescription:
-      "Os óculos chegaram bem rápido (pedi Sedex) e bem embalados, o que era uma das minhas maiores preocupações. Eles foram elogiados pela pessoa mais importantes, minha oftalmologista! Ela disse que ficaram muito bons e realmente, mesmo sendo um grau maior minha lente ficou mais fina que a anterior. As lentes clip-on são muito estilosas também. Recomendo 100%",
-    memberLevel: "gold",
-  },
-  {
-    additionalImage:
-      "https://www.oticaisabeladias.com.br//Images/Blob/Avaliacoes//876231b79dc743c1860a4b7e8d3d8cc7.webp",
-    authorCity: "Florianópolis - SC",
-    authorName: "Maria Fernanda",
-    productLink:
-      "/produto/Armacao-Oculos-Clipon-Grau-Feminino-1271-Isabela-Dias",
-    productName: "Óculos Clipon Redondo Feminino 1271",
-    productPhoto:
-      "https://www.oticaisabeladias.com.br/backoffice//Images/Blob/webp_id//53f3483dfa624952aff955a695e069d9-2.webp",
-    ratingValue: 5,
-    reviewDescription:
-      "A ótica Isabela Dias trabalha com preço justo, qualidade impecável e um atendimento incrível. Sou fã dessa ótica! ",
-    memberLevel: "vip",
-  },
-];
-
-export default function Testimonials(
-  { header, membershipBadges }: Props,
-) {
+export default function Testimonials({ header, membershipBadges, page }: Props) {
   const id = useId();
 
   return (
     <>
       <IconTitle {...header} />
       <div class="w-full container px-4 py-8 flex flex-col gap-14 lg:gap-20 lg:py-10 lg:px-0">
-        <div
-          class="relative w-full px-8"
-          id={id}
-        >
+        <div class="relative w-full px-8" id={id}>
           <Slider class="carousel carousel-start gap-4 lg:gap-8 row-start-2 row-end-5 w-full">
-            {REVIEW_MOCK?.map((review, index) => (
+            {page?.map((review, index) => (
               <Slider.Item
                 index={index}
                 class="flex flex-col gap-4 carousel-item w-full"
@@ -95,7 +43,9 @@ export default function Testimonials(
           </Slider>
 
           <div class="flex flex-row w-full gap-x-3 justify-center items-center py-14 ">
-            {REVIEW_MOCK?.map((_, index) => <Slider.Dot index={index} />)}
+            {page?.map((_, index) => (
+              <Slider.Dot index={index} />
+            ))}
           </div>
 
           <SliderJS


### PR DESCRIPTION
## What is this contribution about?

Get Testimonials loader added


## How to test it?

use [product/testimonials.ts](https://deco.cx/admin/sites/otica-isabela/blocks/?returnLabel=Blocos&returnUrl=%2Fadmin%2Fsites%2Fotica-isabela%2Flibrary&ref=%23%2Fdefinitions%2FZGVjby1zaXRlcy9vdGljYS1pc2FiZWxhL2xvYWRlcnMvcHJvZHVjdC90ZXN0aW1vbmlhbHMudHM%3D&type=product) on deco panel. If you wanna return testimonials from all products, just let the "slug" prop empty.
If you wanna testimonials from a specific product, use the option "https://denopkg.com/deco-sites/std@1.21.7/functions/requestToParam.ts@RequestURLParam" an type a valid product slug. It will return the data in the actual format (Interface Review). Try `armacao-oculos-feminino-gatinho-preto-1661-isabela-dias`

## Extra info

![Capturar](https://github.com/deco-sites/otica-isabela/assets/70353393/f9f723ef-b0ad-4f24-9490-d0f0db0c9a94)

![Capturar2](https://github.com/deco-sites/otica-isabela/assets/70353393/f2bd2ff8-62b6-4d27-bcb9-e22cdaa31b82)

