### PR TITLE
fix(packs): now, product flag is returned properly

### DIFF
--- a/manifest.gen.ts
+++ b/manifest.gen.ts
@@ -2,106 +2,106 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
-import * as $$$0 from "./loaders/product/productList.ts";
-import * as $$$1 from "./loaders/product/productDetails.ts";
-import * as $$$2 from "./loaders/product/wishlist.ts";
-import * as $$$3 from "./loaders/product/productListiningPage.ts";
-import * as $$$4 from "./loaders/product/testimonials.ts";
-import * as $$$5 from "./loaders/product/suggestions.ts";
-import * as $$$6 from "./loaders/product/cart.ts";
-import * as $$$7 from "./loaders/actions/cart/addItem.ts";
-import * as $$$8 from "./loaders/actions/wishlist/removeItem.ts";
-import * as $$$9 from "./loaders/actions/wishlist/addItem.ts";
+import * as $$$0 from "./loaders/actions/cart/addItem.ts";
+import * as $$$1 from "./loaders/actions/wishlist/addItem.ts";
+import * as $$$2 from "./loaders/actions/wishlist/removeItem.ts";
+import * as $$$3 from "./loaders/product/cart.ts";
+import * as $$$4 from "./loaders/product/productDetails.ts";
+import * as $$$5 from "./loaders/product/productList.ts";
+import * as $$$6 from "./loaders/product/productListiningPage.ts";
+import * as $$$7 from "./loaders/product/suggestions.ts";
+import * as $$$8 from "./loaders/product/testimonials.ts";
+import * as $$$9 from "./loaders/product/wishlist.ts";
 import * as $$$10 from "./loaders/store/newsletter.ts";
 import * as $$$11 from "./loaders/store/session.ts";
-import * as $$$$$$0 from "./sections/Footer/Footer.tsx";
-import * as $$$$$$1 from "./sections/Category/CategoryBanner.tsx";
-import * as $$$$$$2 from "./sections/Images/ShoppableBanner.tsx";
-import * as $$$$$$3 from "./sections/Images/BannerGrid.tsx";
-import * as $$$$$$4 from "./sections/Images/ImageGallery.tsx";
-import * as $$$$$$5 from "./sections/Images/InformativeBanner.tsx";
-import * as $$$$$$6 from "./sections/Images/BannerTextButton.tsx";
-import * as $$$$$$7 from "./sections/Images/Carousel.tsx";
-import * as $$$$$$8 from "./sections/Content/Testimonials.tsx";
-import * as $$$$$$9 from "./sections/Content/Logos.tsx";
-import * as $$$$$$10 from "./sections/Content/Faq.tsx";
-import * as $$$$$$11 from "./sections/Content/Benefits.tsx";
-import * as $$$$$$12 from "./sections/Content/About.tsx";
-import * as $$$$$$13 from "./sections/Product/Wishlist.tsx";
-import * as $$$$$$14 from "./sections/Product/ProductBannerShelf.tsx";
-import * as $$$$$$15 from "./sections/Product/SearchResult.tsx";
-import * as $$$$$$16 from "./sections/Product/Details/ProductDetailsAdditionalInfo.tsx";
-import * as $$$$$$17 from "./sections/Product/ProductShelf.tsx";
-import * as $$$$$$18 from "./sections/Product/VisitedProductShelf.tsx";
-import * as $$$$$$19 from "./sections/Product/ProductBestDailyOffers.tsx";
-import * as $$$$$$20 from "./sections/Product/ProductDetails.tsx";
-import * as $$$$$$21 from "./sections/Product/ProductShelfAndImage.tsx";
-import * as $$$$$$22 from "./sections/Miscellaneous/CampaignTimer.tsx";
-import * as $$$$$$23 from "./sections/Miscellaneous/CookieConsent.tsx";
-import * as $$$$$$24 from "./sections/Social/WhatsApp.tsx";
-import * as $$$$$$25 from "./sections/Social/InstagramPosts.tsx";
-import * as $$$$$$26 from "./sections/Theme/Theme.tsx";
-import * as $$$$$$27 from "./sections/Links/LinkTree.tsx";
-import * as $$$$$$28 from "./sections/Links/Shortcuts.tsx";
-import * as $$$$$$29 from "./sections/Newsletter/Newsletter.tsx";
-import * as $$$$$$30 from "./sections/Header/Header.tsx";
+import * as $$$$$$0 from "./sections/Category/CategoryBanner.tsx";
+import * as $$$$$$1 from "./sections/Content/About.tsx";
+import * as $$$$$$2 from "./sections/Content/Benefits.tsx";
+import * as $$$$$$3 from "./sections/Content/Faq.tsx";
+import * as $$$$$$4 from "./sections/Content/Logos.tsx";
+import * as $$$$$$5 from "./sections/Content/Testimonials.tsx";
+import * as $$$$$$6 from "./sections/Footer/Footer.tsx";
+import * as $$$$$$7 from "./sections/Header/Header.tsx";
+import * as $$$$$$8 from "./sections/Images/BannerGrid.tsx";
+import * as $$$$$$9 from "./sections/Images/BannerTextButton.tsx";
+import * as $$$$$$10 from "./sections/Images/Carousel.tsx";
+import * as $$$$$$11 from "./sections/Images/ImageGallery.tsx";
+import * as $$$$$$12 from "./sections/Images/InformativeBanner.tsx";
+import * as $$$$$$13 from "./sections/Images/ShoppableBanner.tsx";
+import * as $$$$$$14 from "./sections/Links/LinkTree.tsx";
+import * as $$$$$$15 from "./sections/Links/Shortcuts.tsx";
+import * as $$$$$$16 from "./sections/Miscellaneous/CampaignTimer.tsx";
+import * as $$$$$$17 from "./sections/Miscellaneous/CookieConsent.tsx";
+import * as $$$$$$18 from "./sections/Newsletter/Newsletter.tsx";
+import * as $$$$$$19 from "./sections/Product/Details/ProductDetailsAdditionalInfo.tsx";
+import * as $$$$$$20 from "./sections/Product/ProductBannerShelf.tsx";
+import * as $$$$$$21 from "./sections/Product/ProductBestDailyOffers.tsx";
+import * as $$$$$$22 from "./sections/Product/ProductDetails.tsx";
+import * as $$$$$$23 from "./sections/Product/ProductShelf.tsx";
+import * as $$$$$$24 from "./sections/Product/ProductShelfAndImage.tsx";
+import * as $$$$$$25 from "./sections/Product/SearchResult.tsx";
+import * as $$$$$$26 from "./sections/Product/VisitedProductShelf.tsx";
+import * as $$$$$$27 from "./sections/Product/Wishlist.tsx";
+import * as $$$$$$28 from "./sections/Social/InstagramPosts.tsx";
+import * as $$$$$$29 from "./sections/Social/WhatsApp.tsx";
+import * as $$$$$$30 from "./sections/Theme/Theme.tsx";
 import * as $$$$$$$$$$$0 from "./apps/decohub.ts";
 import * as $$$$$$$$$$$1 from "./apps/site.ts";
 
 const manifest = {
   "loaders": {
-    "deco-sites/otica-isabela/loaders/actions/cart/addItem.ts": $$$7,
-    "deco-sites/otica-isabela/loaders/actions/wishlist/addItem.ts": $$$9,
-    "deco-sites/otica-isabela/loaders/actions/wishlist/removeItem.ts": $$$8,
-    "deco-sites/otica-isabela/loaders/product/cart.ts": $$$6,
-    "deco-sites/otica-isabela/loaders/product/productDetails.ts": $$$1,
-    "deco-sites/otica-isabela/loaders/product/productList.ts": $$$0,
-    "deco-sites/otica-isabela/loaders/product/productListiningPage.ts": $$$3,
-    "deco-sites/otica-isabela/loaders/product/suggestions.ts": $$$5,
-    "deco-sites/otica-isabela/loaders/product/testimonials.ts": $$$4,
-    "deco-sites/otica-isabela/loaders/product/wishlist.ts": $$$2,
+    "deco-sites/otica-isabela/loaders/actions/cart/addItem.ts": $$$0,
+    "deco-sites/otica-isabela/loaders/actions/wishlist/addItem.ts": $$$1,
+    "deco-sites/otica-isabela/loaders/actions/wishlist/removeItem.ts": $$$2,
+    "deco-sites/otica-isabela/loaders/product/cart.ts": $$$3,
+    "deco-sites/otica-isabela/loaders/product/productDetails.ts": $$$4,
+    "deco-sites/otica-isabela/loaders/product/productList.ts": $$$5,
+    "deco-sites/otica-isabela/loaders/product/productListiningPage.ts": $$$6,
+    "deco-sites/otica-isabela/loaders/product/suggestions.ts": $$$7,
+    "deco-sites/otica-isabela/loaders/product/testimonials.ts": $$$8,
+    "deco-sites/otica-isabela/loaders/product/wishlist.ts": $$$9,
     "deco-sites/otica-isabela/loaders/store/newsletter.ts": $$$10,
     "deco-sites/otica-isabela/loaders/store/session.ts": $$$11,
   },
   "sections": {
-    "deco-sites/otica-isabela/sections/Category/CategoryBanner.tsx": $$$$$$1,
-    "deco-sites/otica-isabela/sections/Content/About.tsx": $$$$$$12,
-    "deco-sites/otica-isabela/sections/Content/Benefits.tsx": $$$$$$11,
-    "deco-sites/otica-isabela/sections/Content/Faq.tsx": $$$$$$10,
-    "deco-sites/otica-isabela/sections/Content/Logos.tsx": $$$$$$9,
-    "deco-sites/otica-isabela/sections/Content/Testimonials.tsx": $$$$$$8,
-    "deco-sites/otica-isabela/sections/Footer/Footer.tsx": $$$$$$0,
-    "deco-sites/otica-isabela/sections/Header/Header.tsx": $$$$$$30,
-    "deco-sites/otica-isabela/sections/Images/BannerGrid.tsx": $$$$$$3,
-    "deco-sites/otica-isabela/sections/Images/BannerTextButton.tsx": $$$$$$6,
-    "deco-sites/otica-isabela/sections/Images/Carousel.tsx": $$$$$$7,
-    "deco-sites/otica-isabela/sections/Images/ImageGallery.tsx": $$$$$$4,
-    "deco-sites/otica-isabela/sections/Images/InformativeBanner.tsx": $$$$$$5,
-    "deco-sites/otica-isabela/sections/Images/ShoppableBanner.tsx": $$$$$$2,
-    "deco-sites/otica-isabela/sections/Links/LinkTree.tsx": $$$$$$27,
-    "deco-sites/otica-isabela/sections/Links/Shortcuts.tsx": $$$$$$28,
+    "deco-sites/otica-isabela/sections/Category/CategoryBanner.tsx": $$$$$$0,
+    "deco-sites/otica-isabela/sections/Content/About.tsx": $$$$$$1,
+    "deco-sites/otica-isabela/sections/Content/Benefits.tsx": $$$$$$2,
+    "deco-sites/otica-isabela/sections/Content/Faq.tsx": $$$$$$3,
+    "deco-sites/otica-isabela/sections/Content/Logos.tsx": $$$$$$4,
+    "deco-sites/otica-isabela/sections/Content/Testimonials.tsx": $$$$$$5,
+    "deco-sites/otica-isabela/sections/Footer/Footer.tsx": $$$$$$6,
+    "deco-sites/otica-isabela/sections/Header/Header.tsx": $$$$$$7,
+    "deco-sites/otica-isabela/sections/Images/BannerGrid.tsx": $$$$$$8,
+    "deco-sites/otica-isabela/sections/Images/BannerTextButton.tsx": $$$$$$9,
+    "deco-sites/otica-isabela/sections/Images/Carousel.tsx": $$$$$$10,
+    "deco-sites/otica-isabela/sections/Images/ImageGallery.tsx": $$$$$$11,
+    "deco-sites/otica-isabela/sections/Images/InformativeBanner.tsx": $$$$$$12,
+    "deco-sites/otica-isabela/sections/Images/ShoppableBanner.tsx": $$$$$$13,
+    "deco-sites/otica-isabela/sections/Links/LinkTree.tsx": $$$$$$14,
+    "deco-sites/otica-isabela/sections/Links/Shortcuts.tsx": $$$$$$15,
     "deco-sites/otica-isabela/sections/Miscellaneous/CampaignTimer.tsx":
-      $$$$$$22,
-    "deco-sites/otica-isabela/sections/Miscellaneous/CookieConsent.tsx":
-      $$$$$$23,
-    "deco-sites/otica-isabela/sections/Newsletter/Newsletter.tsx": $$$$$$29,
-    "deco-sites/otica-isabela/sections/Product/Details/ProductDetailsAdditionalInfo.tsx":
       $$$$$$16,
-    "deco-sites/otica-isabela/sections/Product/ProductBannerShelf.tsx":
-      $$$$$$14,
-    "deco-sites/otica-isabela/sections/Product/ProductBestDailyOffers.tsx":
+    "deco-sites/otica-isabela/sections/Miscellaneous/CookieConsent.tsx":
+      $$$$$$17,
+    "deco-sites/otica-isabela/sections/Newsletter/Newsletter.tsx": $$$$$$18,
+    "deco-sites/otica-isabela/sections/Product/Details/ProductDetailsAdditionalInfo.tsx":
       $$$$$$19,
-    "deco-sites/otica-isabela/sections/Product/ProductDetails.tsx": $$$$$$20,
-    "deco-sites/otica-isabela/sections/Product/ProductShelf.tsx": $$$$$$17,
-    "deco-sites/otica-isabela/sections/Product/ProductShelfAndImage.tsx":
+    "deco-sites/otica-isabela/sections/Product/ProductBannerShelf.tsx":
+      $$$$$$20,
+    "deco-sites/otica-isabela/sections/Product/ProductBestDailyOffers.tsx":
       $$$$$$21,
-    "deco-sites/otica-isabela/sections/Product/SearchResult.tsx": $$$$$$15,
+    "deco-sites/otica-isabela/sections/Product/ProductDetails.tsx": $$$$$$22,
+    "deco-sites/otica-isabela/sections/Product/ProductShelf.tsx": $$$$$$23,
+    "deco-sites/otica-isabela/sections/Product/ProductShelfAndImage.tsx":
+      $$$$$$24,
+    "deco-sites/otica-isabela/sections/Product/SearchResult.tsx": $$$$$$25,
     "deco-sites/otica-isabela/sections/Product/VisitedProductShelf.tsx":
-      $$$$$$18,
-    "deco-sites/otica-isabela/sections/Product/Wishlist.tsx": $$$$$$13,
-    "deco-sites/otica-isabela/sections/Social/InstagramPosts.tsx": $$$$$$25,
-    "deco-sites/otica-isabela/sections/Social/WhatsApp.tsx": $$$$$$24,
-    "deco-sites/otica-isabela/sections/Theme/Theme.tsx": $$$$$$26,
+      $$$$$$26,
+    "deco-sites/otica-isabela/sections/Product/Wishlist.tsx": $$$$$$27,
+    "deco-sites/otica-isabela/sections/Social/InstagramPosts.tsx": $$$$$$28,
+    "deco-sites/otica-isabela/sections/Social/WhatsApp.tsx": $$$$$$29,
+    "deco-sites/otica-isabela/sections/Theme/Theme.tsx": $$$$$$30,
   },
   "apps": {
     "deco-sites/otica-isabela/apps/decohub.ts": $$$$$$$$$$$0,

--- a/packs/types.ts
+++ b/packs/types.ts
@@ -63,6 +63,7 @@ export interface Product {
   ValorDesconto: number;
   OfertaSeraLiberada: string;
   OfertaTermina: string;
+  OfertaFlag?: string,
   PorcentagemDesconto: number;
   ProdutosMaisCores: ColorVariants[];
   Paineis: Panels[];

--- a/packs/utils/transform.ts
+++ b/packs/utils/transform.ts
@@ -33,6 +33,14 @@ type CategoryPageProps =
   >
   & { filtersUrl: DynamicFilter[] | undefined };
 
+interface ToAdditionalPropertiesProps {
+  properties: ProductInfo[];
+  variants: ColorVariants[];
+  experimentador: string;
+  panels: Panels[];
+  flag?: string;
+}
+
 export function toProduct(product: IsabelaProduct): Product {
   const {
     IdProduct,
@@ -51,6 +59,7 @@ export function toProduct(product: IsabelaProduct): Product {
     Paineis,
     DescricaoSeo,
     IdSku,
+    OfertaFlag,
   } = product;
 
   const productImages = Imagens.map((image: Image) => image.Imagem);
@@ -75,12 +84,13 @@ export function toProduct(product: IsabelaProduct): Product {
       alternateName: Nome,
       url: image,
     })),
-    additionalProperty: toAdditionalProperties(
-      productsInfo,
-      ProdutosMaisCores,
-      ImagemExperimentador,
-      Paineis,
-    ),
+    additionalProperty: toAdditionalProperties({
+      properties: productsInfo,
+      variants: ProdutosMaisCores,
+      experimentador: ImagemExperimentador,
+      panels: Paineis,
+      flag: OfertaFlag,
+    }),
     isVariantOf,
     offers: toAggregateOffer(
       ValorOriginal,
@@ -117,12 +127,10 @@ const toUrl = (UrlFriendlyColor: string) =>
     .href;
 
 const toAdditionalProperties = (
-  properties: ProductInfo[],
-  variants: ColorVariants[],
-  experimentador: string,
-  panels: Panels[],
+  props: ToAdditionalPropertiesProps,
 ): PropertyValue[] => {
   const additionalProperties: PropertyValue[] = [];
+  const { variants, properties, panels, experimentador, flag } = props;
 
   if (variants.length > 0) {
     additionalProperties.push(
@@ -150,6 +158,17 @@ const toAdditionalProperties = (
       "value": experimentador,
     },
   );
+
+  if (flag) {
+    additionalProperties.push(
+      {
+        "@type": "PropertyValue" as const,
+        "name": "Flag",
+        "propertyID": "flag",
+        "value": flag,
+      },
+    );
+  }
 
   return additionalProperties;
 };


### PR DESCRIPTION
## What is this contribution about?

Now, product flags like "compre com lentes" are been returning properly.

## How to test it?

https://deco.cx/admin/sites/otica-isabela/blocks/new?returnLabel=Blocks&returnUrl=%2Fadmin%2Fsites%2Fotica-isabela%2Flibrary&ref=%23%2Fdefinitions%2FZGVjby1zaXRlcy9vdGljYS1pc2FiZWxhL2xvYWRlcnMvcHJvZHVjdC9wcm9kdWN0RGV0YWlscy50cw%3D%3D&type=product&sidebarMode=edit&tab=0
type an slug of a product that have this property

## Extra info

![Capturar](https://github.com/deco-sites/otica-isabela/assets/70353393/35a23a8b-cf9d-40eb-8f79-49abb267642c)

