### PR TITLE
fix(packs): now, product rating is returned properly

### DIFF
--- a/packs/types.ts
+++ b/packs/types.ts
@@ -71,6 +71,7 @@ export interface Product {
   ImagemExperimentador: string;
   UrlFriendlyColor: string;
   Classificacoes: ProductInfo[];
+  Avaliacoes: number
 }
 
 export interface ColorVariants {


### PR DESCRIPTION
## What is this contribution about?

Now, product rating is returned properly.

## How to test it?

https://deco.cx/admin/sites/otica-isabela/blocks/new?returnLabel=Blocos&returnUrl=%2Fadmin%2Fsites%2Fotica-isabela%2Flibrary&ref=%23%2Fdefinitions%2FZGVjby1zaXRlcy9vdGljYS1pc2FiZWxhL2xvYWRlcnMvcHJvZHVjdC9wcm9kdWN0RGV0YWlscy50cw%3D%3D&type=product&sidebarMode=edit&tab=0

## Extra info
![Capturar](https://github.com/deco-sites/otica-isabela/assets/70353393/6210f684-9fda-49e6-9c42-1b87e0353a47)


