### PR TITLE
fix(packs): range filters

### DIFF
--- a/packs/constants.ts
+++ b/packs/constants.ts
@@ -23,3 +23,4 @@ export const SORT_OPTIONS: SortOption[] = [
     label: "Nome",
   },
 ];
+export const RANGE_FILTERS = [17, 18, 19, 21];


### PR DESCRIPTION
## What is this contribution about?

Now, range filters are properly returned by the PLP loader. 

## How to test it?

Use the PLP loader in deco admin and type an url of a category.

## Extra info

![Capturar](https://github.com/deco-sites/otica-isabela/assets/70353393/e33d3aed-7b92-42ec-b0a2-e11968c1091b)

